### PR TITLE
upgrade to bevy 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_oneshot"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["SDesya74 <sdesya74@gmail.com>"]
 description = "Simple ohe-shot systems for Bevy"
@@ -13,4 +13,4 @@ license = "MIT OR Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = "0.11.2"
+bevy = "0.13"


### PR DESCRIPTION
Upgrade to bevy's minor version 0.13 allowing all fixes as well